### PR TITLE
Fix: 예약 정보 페이징 시 데이터 중복 문제 해결

### DIFF
--- a/src/main/java/com/chargeset/chargeset_server/repository/reservation/ReservationCustomRepositoryImpl.java
+++ b/src/main/java/com/chargeset/chargeset_server/repository/reservation/ReservationCustomRepositoryImpl.java
@@ -39,7 +39,10 @@ public class ReservationCustomRepositoryImpl implements ReservationCustomReposit
                 .lt(todayRangeInKST.getSecond());
         MatchOperation match = Aggregation.match(criteria);
 
-        SortOperation sort = Aggregation.sort(Sort.by("startTime").ascending());
+        SortOperation sort = Aggregation.sort(Sort.by(
+                Sort.Order.asc("startTime"),
+                Sort.Order.asc("_id")
+        ));
 
         SkipOperation skip = Aggregation.skip(pageable.getOffset());
         LimitOperation limit = Aggregation.limit(pageable.getPageSize());
@@ -71,7 +74,10 @@ public class ReservationCustomRepositoryImpl implements ReservationCustomReposit
 
         MatchOperation match = Aggregation.match(criteria);
 
-        SortOperation sort = Aggregation.sort(Sort.by("startTime").ascending());
+        SortOperation sort = Aggregation.sort(Sort.by(
+                Sort.Order.desc("startTime"),
+                Sort.Order.asc("_id")  // Sort 안정성 - 페이징시 중복을 피하기 위해 키 필드 추가
+        ));
 
         SkipOperation skip = Aggregation.skip(pageable.getOffset());
         LimitOperation limit = Aggregation.limit(pageable.getPageSize());


### PR DESCRIPTION
skip을 이용한 mongo DB 페이징  쿼리 구현 시 
정렬 안정성을 지키지 못해 도큐먼트의 중복과 누락이 발생했습니다.


### MongoDB 공식문서 중...
> _If multiple documents have the same value for the sort key, the order of those documents is undefined._

정렬 키가 동일한 문서가 여러 개 있으면, 그 문서들 사이의 순서는 정의되어 있지 않다는 뜻으로
정렬이 “불안정적(unstable)“일때 이 문서들의 순서를 보장할 수 없다는 내용입니다.


이러한 불안정한 상황에서 페이징을 구현하기 위해
내부적으로 `skip()` `limit()` 이용해 커스텀 쿼리를 작성하였습니다.

문제는 `skip()`을 사용하는 과정에서 발생할 수 있습니다.

➡️ `skip()`의 동작은 내부적으로 정렬 순서에 의존하므로, 중복된 정렬 키 값이 있으면 정확한 페이지 경계가 깨지게 됩니다.


이를 해결하기 위해
기존에 중복값을 가지고 있었던 정렬 키외에 도큐먼트들을 유일하게 식별할 수 있는 objectId 를 추가하여 정렬의 안정화로 오류를 해결했습니다.


커스텀 쿼리 버그 수정 -> ReservationCustomRepositoryImpl