### PR TITLE
Feat: 충전소별 충전 이용 비교 그래프 기능 구현 (충전 이력 탭)

### DIFF
--- a/src/main/java/com/chargeset/chargeset_server/controller/ChargingStationApiController.java
+++ b/src/main/java/com/chargeset/chargeset_server/controller/ChargingStationApiController.java
@@ -2,6 +2,7 @@ package com.chargeset.chargeset_server.controller;
 
 import com.chargeset.chargeset_server.dto.charging_station.ChargingStationInfo;
 import com.chargeset.chargeset_server.dto.tansaction.ChargingDailyStat;
+import com.chargeset.chargeset_server.dto.tansaction.ChargingStatResponse;
 import com.chargeset.chargeset_server.dto.tansaction.HourlyStatResponse;
 import com.chargeset.chargeset_server.service.ChargingStationService;
 import com.chargeset.chargeset_server.service.TransactionService;
@@ -59,5 +60,13 @@ public class ChargingStationApiController {
             searchingDate = LocalDate.now();
         }
         return ResponseEntity.ok(transactionService.getHourlyChargingStats(stationId, searchingDate));
+    }
+
+    /**
+     * 5. 최근 한달 충전소 주간 운영 그래프 - 충전 이력
+     */
+    @GetMapping("/{stationId}/monthly-revenue")
+    public ResponseEntity<ChargingStatResponse> getMonthlyRevenueStat(@PathVariable(name = "stationId") String stationId) {
+        return ResponseEntity.ok(transactionService.getMonthlyChargingStats(stationId));
     }
 }

--- a/src/main/java/com/chargeset/chargeset_server/controller/HomeController.java
+++ b/src/main/java/com/chargeset/chargeset_server/controller/HomeController.java
@@ -47,6 +47,8 @@ public class HomeController {
 
     @GetMapping("/transactions")
     public String transactions(Model model) {
+        List<ChargingStationInfo> chargingStationsLocation = chargingStationService.getChargingStationsInfo();
+        model.addAttribute("chargingStations", chargingStationsLocation);
         model.addAttribute("activePage", "transaction");
         return "transaction";
     }

--- a/src/main/java/com/chargeset/chargeset_server/controller/TransactionApiController.java
+++ b/src/main/java/com/chargeset/chargeset_server/controller/TransactionApiController.java
@@ -63,11 +63,4 @@ public class TransactionApiController {
         return ResponseEntity.ok(transactionService.getChargingProfile(transactionId));
     }
 
-    /**
-     * 5. 최근 한달 충전소 주간 운영 그래프 - 충전 이력
-     */
-    @GetMapping("/{stationId}/monthly-revenue")
-    public ResponseEntity<ChargingStatResponse> getMonthlyRevenueStat(@PathVariable(name = "stationId") String stationId) {
-        return ResponseEntity.ok(transactionService.getMonthlyChargingStats(stationId));
-    }
 }

--- a/src/main/java/com/chargeset/chargeset_server/controller/TransactionApiController.java
+++ b/src/main/java/com/chargeset/chargeset_server/controller/TransactionApiController.java
@@ -56,11 +56,18 @@ public class TransactionApiController {
     }
 
     /**
-     * 4. 충전 프로파일 조회
+     * 4. 충전 프로파일 조회 - 충전 이력
      */
     @GetMapping("/{transactionId}/charging-profile")
     public ResponseEntity<ChargingProfileResponse> getChargingProfile(@PathVariable(name = "transactionId") String transactionId) {
         return ResponseEntity.ok(transactionService.getChargingProfile(transactionId));
     }
 
+    /**
+     * 5. 최근 한달 충전소 주간 운영 그래프 - 충전 이력
+     */
+    @GetMapping("/{stationId}/monthly-revenue")
+    public ResponseEntity<ChargingStatResponse> getMonthlyRevenueStat(@PathVariable(name = "stationId") String stationId) {
+        return ResponseEntity.ok(transactionService.getMonthlyChargingStats(stationId));
+    }
 }

--- a/src/main/java/com/chargeset/chargeset_server/controller/TransactionApiController.java
+++ b/src/main/java/com/chargeset/chargeset_server/controller/TransactionApiController.java
@@ -34,7 +34,7 @@ public class TransactionApiController {
      * 2. 주간 운영 그래프 - 대시보드
      */
     @GetMapping("/weekly-revenue")
-    public ResponseEntity<WeeklyStatResponse> getWeeklyRevenueStat() {
+    public ResponseEntity<ChargingStatResponse> getWeeklyRevenueStat() {
         return ResponseEntity.ok(transactionService.getWeeklyChargingStats());
     }
 

--- a/src/main/java/com/chargeset/chargeset_server/dto/tansaction/ChargingStatResponse.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/tansaction/ChargingStatResponse.java
@@ -1,0 +1,15 @@
+package com.chargeset.chargeset_server.dto.tansaction;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class ChargingStatResponse {
+    private long totalCount;
+    private long totalRevenue;
+    private long totalEnergy;
+    private List<ChargingDailyStat> dailyStats;
+}

--- a/src/main/java/com/chargeset/chargeset_server/repository/transaction/TransactionCustomRepository.java
+++ b/src/main/java/com/chargeset/chargeset_server/repository/transaction/TransactionCustomRepository.java
@@ -26,4 +26,6 @@ public interface TransactionCustomRepository {
                                                             TransactionStatus status, Pageable pageable);
 
     Optional<ChargingProfileResponse> findChargingProfileById(String id);
+
+    List<ChargingDailyStat> getMonthlyChargingStatsByStationId(String stationId);
 }

--- a/src/main/java/com/chargeset/chargeset_server/repository/transaction/TransactionCustomRepositoryImpl.java
+++ b/src/main/java/com/chargeset/chargeset_server/repository/transaction/TransactionCustomRepositoryImpl.java
@@ -157,15 +157,13 @@ public class TransactionCustomRepositoryImpl implements TransactionCustomReposit
     @Override
     public Page<TransactionInfoResponse> findTransactionWithFilter(LocalDate from, LocalDate to, String stationId, TransactionStatus transactionStatus, Pageable pageable) {
 
-        System.out.println("#####");
-
         Criteria criteria = getSearchingConditionCriteria(from, to, stationId, transactionStatus);
 
         MatchOperation match = Aggregation.match(criteria);
 
         SortOperation sort = Aggregation.sort(Sort.by(
                 Sort.Order.desc("endTime"),
-                Sort.Order.asc("_id")  // ✅ 유일한 필드 추가
+                Sort.Order.asc("_id")
         ));
 
         SkipOperation skip = Aggregation.skip(pageable.getOffset());

--- a/src/main/java/com/chargeset/chargeset_server/service/TransactionService.java
+++ b/src/main/java/com/chargeset/chargeset_server/service/TransactionService.java
@@ -46,13 +46,13 @@ public class TransactionService {
     /**
      * 3. 주간 매출, 전력, 사용횟수 조회
      */
-    public WeeklyStatResponse getWeeklyChargingStats() {
+    public ChargingStatResponse getWeeklyChargingStats() {
 
         List<ChargingDailyStat> actualResults = transactionRepository.getWeeklyChargingStats();
 
         List<LocalDate> last7Days = getLastDaysList(6);
 
-        return buildWeeklyStatResponse(actualResults, last7Days);
+        return buildChargingStatResponse(actualResults, last7Days);
     }
 
 
@@ -91,12 +91,12 @@ public class TransactionService {
 
         List<ChargingDailyStat> actualResults = transactionRepository.getMonthlyChargingStatsByStationId(stationId);
         List<LocalDate> last30Days = getLastDaysList(29);
-        return buildMonthlyStatResponse(actualResults, last30Days);
+        return buildChargingStatResponse(actualResults, last30Days);
     }
 
 
     //== 메서드 ==//
-    private static ChargingStatResponse buildMonthlyStatResponse(List<ChargingDailyStat> actualResults, List<LocalDate> last30Days) {
+    private static ChargingStatResponse buildChargingStatResponse(List<ChargingDailyStat> actualResults, List<LocalDate> last30Days) {
         Map<LocalDate, ChargingDailyStat> statMap = actualResults.stream()
                 .collect(Collectors.toMap(ChargingDailyStat::getDate, stat -> stat));
 
@@ -111,23 +111,6 @@ public class TransactionService {
             fullMonthData.add(stat);
         }
         return new ChargingStatResponse(totalCount, totalRevenue, totalEnergy, fullMonthData);
-    }
-
-    private static WeeklyStatResponse buildWeeklyStatResponse(List<ChargingDailyStat> actualResults, List<LocalDate> last7Days) {
-        Map<LocalDate, ChargingDailyStat> statMap = actualResults.stream()
-                .collect(Collectors.toMap(ChargingDailyStat::getDate, stat -> stat));
-
-        List<ChargingDailyStat> fullWeekData = new ArrayList<>();
-        long totalCount = 0, totalRevenue = 0, totalEnergy = 0;
-
-        for (LocalDate date : last7Days) {
-            ChargingDailyStat stat = statMap.getOrDefault(date, new ChargingDailyStat(date, 0, 0, 0));
-            totalCount += stat.getCount();
-            totalRevenue += stat.getTotalRevenue();
-            totalEnergy += stat.getTotalEnergy();
-            fullWeekData.add(stat);
-        }
-        return new WeeklyStatResponse(totalCount, totalRevenue, totalEnergy, fullWeekData);
     }
 
     private static HourlyStatResponse buildHourlyStatResponse(String stationId, LocalDate searchingDate, List<ChargingHourlyStat> actualResults) {

--- a/src/main/java/com/chargeset/chargeset_server/utils/TimeUtils.java
+++ b/src/main/java/com/chargeset/chargeset_server/utils/TimeUtils.java
@@ -28,6 +28,14 @@ public class TimeUtils {
         return Pair.of(startOfDay, endOfDay);
     }
 
+    public static Pair<Instant, Instant> getMonthlyRangeInKST() {
+        LocalDate today = LocalDate.now(KST);
+        LocalDate sevenDaysAgo = today.minusDays(30);
+        Instant startOfDay = sevenDaysAgo.atStartOfDay(KST).toInstant();
+        Instant endOfDay = today.plusDays(1).atStartOfDay(KST).toInstant();
+        return Pair.of(startOfDay, endOfDay);
+    }
+
     public static Pair<Instant, Instant> getInputDayRangeInKST(LocalDate date) {
         Instant startOfDay = date.atStartOfDay(KST).toInstant();
         Instant endOfDay = date.plusDays(1).atStartOfDay(KST).toInstant();

--- a/src/main/resources/static/css/transaction.css
+++ b/src/main/resources/static/css/transaction.css
@@ -1,1 +1,5 @@
 /* transaction.css */
+
+#summary-cards .card {
+    border-width: 2px;
+}

--- a/src/main/resources/static/js/dashboard.js
+++ b/src/main/resources/static/js/dashboard.js
@@ -4,7 +4,7 @@
 async function fetchWeeklyStats() {
     const res = await fetch('/api/transactions/weekly-revenue');
     const result = await res.json();
-    const data = result.data; // ✅ 일별 데이터만 추출
+    const data = result.dailyStats; // 일별 데이터만 추출
 
     const labels = data.map(d =>
         new Date(d.date).toLocaleDateString('ko-KR', { month: '2-digit', day: '2-digit' })
@@ -42,7 +42,7 @@ async function fetchWeeklyStats() {
         data: {
             labels: labels,
             datasets: [{
-                label: '전력량 (kWh)',
+                label: '전력량 (Wh)',
                 data: energy,
                 borderColor: '#4dabf7',
                 backgroundColor: 'transparent',

--- a/src/main/resources/templates/station.html
+++ b/src/main/resources/templates/station.html
@@ -48,7 +48,6 @@
       </div>
     </div>
 
-    <!-- 지도 + EVSE 현황 -->
     <div class="row mb-4">
       <div class="col-lg-6 col-12 mb-4">
         <div class="card-box">
@@ -76,30 +75,10 @@
 
       <div class="col-lg-6 col-12 mb-4">
         <div class="card-box h-100 d-flex flex-column justify-content-between" style="height: 400px;">
-          <div class="section-title text-start">전력 단가 비교</div>
+          <div class="section-title text-start">사용자 재방문률</div>
 
         </div>
       </div>
-    </div>
-
-
-    <!-- 예약 -->
-    <div class="card-box">
-      <div class="section-title">충전 기록</div>
-      <div id="transaction-container">
-
-      </div>
-
-    </div>
-
-
-    <!-- 예약 -->
-    <div class="card-box">
-      <div class="section-title">예약</div>
-      <div id="reservation-container">
-
-      </div>
-
     </div>
 
 

--- a/src/main/resources/templates/transaction.html
+++ b/src/main/resources/templates/transaction.html
@@ -19,10 +19,63 @@
     <h1 class="page-title">충전 이력 조회</h1>
     <hr>
 
+    <!-- 전체 충전 이력 조회  -->
+    <div class="card-box">
+
+      <div class="section-title mb-3">최근 한달 이용 통계 비교</div>
+
+      <!-- 조회 기준 선택 -->
+      <div class="d-flex mb-3 gap-2 align-items-center">
+        <select id="stat-metric" class="form-select" style="max-width: 160px;">
+          <option value="count">충전 횟수</option>
+          <option value="totalEnergy">전력 사용량</option>
+          <option value="totalRevenue">매출</option>
+        </select>
+        <button class="btn btn-primary" >검색</button>
+      </div>
+
+      <!-- 그래프 -->
+
+
+    </div>
+
+
+    <div class="row mb-4">
+      <div class="col-lg-6 col-12 mb-4">
+        <div class="card-box">
+          <div class="section-title mb-3">최근 한달 이용 통계 비교</div>
+
+          <!-- 조회 기준 선택 -->
+          <div class="d-flex mb-3 gap-2 align-items-center">
+            <select id="stat-metric2" class="form-select" style="max-width: 160px;">
+              <option value="count">충전 횟수</option>
+              <option value="totalEnergy">전력 사용량</option>
+              <option value="totalRevenue">매출</option>
+            </select>
+            <button class="btn btn-primary" >검색</button>
+          </div>
 
 
 
-  <!-- 전체 충전 이력 조회  -->
+        </div>
+      </div>
+
+
+
+      <div class="col-lg-6 col-12 mb-4">
+        <div class="card-box">
+          <div class="section-title mb-3">충전 상태</div>
+
+
+
+
+        </div>
+      </div>
+    </div>
+
+
+
+    <!-- 전체 충전 이력 조회  -->
     <div class="card-box">
       <div class="section-title">충전 이력 조회</div>
 

--- a/src/main/resources/templates/transaction.html
+++ b/src/main/resources/templates/transaction.html
@@ -19,10 +19,10 @@
     <h1 class="page-title">충전 이력 조회</h1>
     <hr>
 
-    <!-- 전체 충전 이력 조회  -->
+    <!-- 한달 이용 비교 통계  -->
     <div class="card-box">
 
-      <div class="section-title mb-3">최근 한달 이용 통계 비교</div>
+      <div class="section-title mb-3">최근 30일 이용 비교 통계</div>
 
       <!-- 조회 기준 선택 -->
       <div class="d-flex mb-3 gap-2 align-items-center">
@@ -31,48 +31,50 @@
           <option value="totalEnergy">전력 사용량</option>
           <option value="totalRevenue">매출</option>
         </select>
-        <button class="btn btn-primary" >검색</button>
+        <button class="btn btn-primary" onclick="fetchMonthlyChartData()">검색</button>
+      </div>
+
+      <!-- 총 매출 요약 -->
+      <div class="row row-cols-1 row-cols-md-2 g-3 mb-4" id="summary-cards">
+        <div class="col">
+          <div class="card border-primary shadow-sm h-100">
+            <div class="card-body">
+              <h5 class="card-title text-primary" id="summary-first-title">충전소 1</h5>
+              <p class="card-text mb-1">
+                <strong>총 매출:</strong> <span id="summary-first-revenue">-</span> 원
+              </p>
+              <p class="card-text mb-1">
+                <strong>총 전력량:</strong> <span id="summary-first-energy">-</span> Wh
+              </p>
+              <p class="card-text mb-0">
+                <strong>총 충전 횟수:</strong> <span id="summary-first-count">-</span> 회
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col">
+          <div class="card border-success shadow-sm h-100">
+            <div class="card-body">
+              <h5 class="card-title text-success" id="summary-second-title">충전소 2</h5>
+              <p class="card-text mb-1">
+                <strong>총 매출:</strong> <span id="summary-second-revenue">-</span> 원
+              </p>
+              <p class="card-text mb-1">
+                <strong>총 전력량:</strong> <span id="summary-second-energy">-</span> Wh
+              </p>
+              <p class="card-text mb-0">
+                <strong>총 충전 횟수:</strong> <span id="summary-second-count">-</span> 회
+              </p>
+            </div>
+          </div>
+        </div>
       </div>
 
       <!-- 그래프 -->
-
+      <canvas id="monthlyChartCanvas" height="100"></canvas>
 
     </div>
-
-
-    <div class="row mb-4">
-      <div class="col-lg-6 col-12 mb-4">
-        <div class="card-box">
-          <div class="section-title mb-3">최근 한달 이용 통계 비교</div>
-
-          <!-- 조회 기준 선택 -->
-          <div class="d-flex mb-3 gap-2 align-items-center">
-            <select id="stat-metric2" class="form-select" style="max-width: 160px;">
-              <option value="count">충전 횟수</option>
-              <option value="totalEnergy">전력 사용량</option>
-              <option value="totalRevenue">매출</option>
-            </select>
-            <button class="btn btn-primary" >검색</button>
-          </div>
-
-
-
-        </div>
-      </div>
-
-
-
-      <div class="col-lg-6 col-12 mb-4">
-        <div class="card-box">
-          <div class="section-title mb-3">충전 상태</div>
-
-
-
-
-        </div>
-      </div>
-    </div>
-
 
 
     <!-- 전체 충전 이력 조회  -->
@@ -112,7 +114,6 @@
           <input type="date" id="to-date" class="form-control" style="min-width: 160px;">
         </div>
 
-
         <!-- 검색 버튼 -->
         <div class="align-self-end">
           <button class="btn btn-primary" id="search-button">검색</button>
@@ -139,14 +140,13 @@
           </tbody>
         </table>
       </div>
+
       <nav id="pagination" class="mt-4 d-flex justify-content-center">
         <ul class="pagination" id="pagination-list">
           <!-- 페이징 버튼이 여기에 동적으로 채워짐 -->
         </ul>
       </nav>
     </div>
-
-
 
   </div>
 
@@ -190,15 +190,14 @@
   </div>
 
 
-
-
-
-
 </div>
 
 
 <th:block id="page-script">
 
+  <script th:inline="javascript">
+    window.chargingStations = /*[[${chargingStations}]]*/ [];
+  </script>
 
   <!-- 분리된 JS 파일 로딩 -->
   <script th:src="@{/js/pagination.js}"></script>


### PR DESCRIPTION
## 충전 이용 비교 그래프 기능

### 1. 최근 30일, 충전소별 하루 이용 정보를 종합하여 통계를 내는 API 구현
> 조회 당일부터 30일 전까지의 각 하루 매출, 이용량 전력 사용량과 
30일 총 매출, 총 이용량, 총 전력사용량을 조회하는 API입니다.


[요청]
GET: `/api/stations/{stationId}/monthly-revenue`


[응답]
```json
{
    "totalCount": 13,
    "totalRevenue": 40300,
    "totalEnergy": 104000,
    "dailyStats": [
        {
            "date": "2025-03-24",
            "totalRevenue": 0,
            "totalEnergy": 0,
            "count": 0
        },
        {
            "date": "2025-03-25",
            "totalRevenue": 0,
            "totalEnergy": 0,
            "count": 0
        },
        .....
    ]
}
```

<br>

### 2. API를 통해 받은 데이터를 그래프로 보여주는 UI  구현
> 충전소 2개에 대해 조회 API를 호출하고 한 그래프 차트 내에 같이 보여주어 비교 가능하게끔 가시적으로 확인할 수 있습니다.

1. 검색 조건으로 충전 횟수, 전력 사용량, 매출 중 하나를 선택하여 그래프를 확인할 수 있습니다.
2. 그래프에 마우스를 hover하면 구체적인 수치를 확인할 수 있습니다.
3. 한 달 total 집계 결과를 확인할 수 있습니다.

[UI]
<img width="1901" alt="image" src="https://github.com/user-attachments/assets/3e3add32-da66-49c0-a4bf-dfff6d7ff1c4" />
