### PR TITLE
Feat: 사용자 재방문 통계 기능 구현 (충전소별 현황 탭)

### DIFF
--- a/src/main/java/com/chargeset/chargeset_server/controller/ChargingStationApiController.java
+++ b/src/main/java/com/chargeset/chargeset_server/controller/ChargingStationApiController.java
@@ -3,6 +3,7 @@ package com.chargeset.chargeset_server.controller;
 import com.chargeset.chargeset_server.dto.charging_station.ChargingStationInfo;
 import com.chargeset.chargeset_server.dto.tansaction.ChargingDailyStat;
 import com.chargeset.chargeset_server.dto.tansaction.ChargingStatResponse;
+import com.chargeset.chargeset_server.dto.tansaction.ChargingUsageResponse;
 import com.chargeset.chargeset_server.dto.tansaction.HourlyStatResponse;
 import com.chargeset.chargeset_server.service.ChargingStationService;
 import com.chargeset.chargeset_server.service.TransactionService;
@@ -69,4 +70,13 @@ public class ChargingStationApiController {
     public ResponseEntity<ChargingStatResponse> getMonthlyRevenueStat(@PathVariable(name = "stationId") String stationId) {
         return ResponseEntity.ok(transactionService.getMonthlyChargingStats(stationId));
     }
+
+    /**
+     * 6. 충전소별 사용자 이용률 통계 - 충전소별 현황
+     */
+    @GetMapping("/{stationId}/user-usage-summary")
+    public ResponseEntity<ChargingUsageResponse> getUserUsageSummary(@PathVariable(name = "stationId") String stationId) {
+        return ResponseEntity.ok(transactionService.getChargingUsageSummary(stationId));
+    }
+
 }

--- a/src/main/java/com/chargeset/chargeset_server/dto/tansaction/ChargingUsageResponse.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/tansaction/ChargingUsageResponse.java
@@ -1,0 +1,14 @@
+package com.chargeset.chargeset_server.dto.tansaction;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ChargingUsageResponse {
+
+    private long once;
+    private long twice;
+    private long thirdAndFourth;
+    private long fifthOrMore;
+}

--- a/src/main/java/com/chargeset/chargeset_server/dto/tansaction/UsageBucketResult.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/tansaction/UsageBucketResult.java
@@ -1,0 +1,11 @@
+package com.chargeset.chargeset_server.dto.tansaction;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class UsageBucketResult {
+    private String id;
+    private long userCount;
+}

--- a/src/main/java/com/chargeset/chargeset_server/repository/transaction/TransactionCustomRepository.java
+++ b/src/main/java/com/chargeset/chargeset_server/repository/transaction/TransactionCustomRepository.java
@@ -1,10 +1,7 @@
 package com.chargeset.chargeset_server.repository.transaction;
 
 import com.chargeset.chargeset_server.document.status.TransactionStatus;
-import com.chargeset.chargeset_server.dto.tansaction.ChargingDailyStat;
-import com.chargeset.chargeset_server.dto.tansaction.ChargingHourlyStat;
-import com.chargeset.chargeset_server.dto.tansaction.ChargingProfileResponse;
-import com.chargeset.chargeset_server.dto.tansaction.TransactionInfoResponse;
+import com.chargeset.chargeset_server.dto.tansaction.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -28,4 +25,6 @@ public interface TransactionCustomRepository {
     Optional<ChargingProfileResponse> findChargingProfileById(String id);
 
     List<ChargingDailyStat> getMonthlyChargingStatsByStationId(String stationId);
+
+    List<UsageBucketResult> getUserChargingUsageSummaryByStationId(String stationId);
 }

--- a/src/main/java/com/chargeset/chargeset_server/service/TransactionService.java
+++ b/src/main/java/com/chargeset/chargeset_server/service/TransactionService.java
@@ -94,6 +94,30 @@ public class TransactionService {
         return buildChargingStatResponse(actualResults, last30Days);
     }
 
+    /**
+     * 8. 충전소별 사용자 이용 통계
+     */
+    public ChargingUsageResponse getChargingUsageSummary(String transactionId) {
+        List<UsageBucketResult> results = transactionRepository.getUserChargingUsageSummaryByStationId(transactionId);
+
+        long once = 0;
+        long twice = 0;
+        long thirdAndFourth = 0;
+        long fifthOrMore = 0;
+
+        for (UsageBucketResult result : results) {
+            switch (result.getId()) {
+                case "1" -> once += result.getUserCount();
+                case "2" -> twice += result.getUserCount();
+                case "3" -> thirdAndFourth += result.getUserCount();
+                case "4" -> thirdAndFourth += result.getUserCount();
+                default -> fifthOrMore += result.getUserCount();
+            }
+        }
+
+        return new ChargingUsageResponse(once, twice, thirdAndFourth, fifthOrMore);
+    }
+
 
     //== 메서드 ==//
     private static ChargingStatResponse buildChargingStatResponse(List<ChargingDailyStat> actualResults, List<LocalDate> last30Days) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
       host: localhost
       port: 27017
       database: charge-set
+    #uri: mongodb://localhost:27017/charge-set?maxPoolSize=100&minPoolSize=5&maxIdleTimeMS=60000&waitQueueTimeoutMS=10000   # 커넥션 풀 설정
     #uri: ${MONGO_URI}
 
 logging:

--- a/src/main/resources/templates/station.html
+++ b/src/main/resources/templates/station.html
@@ -67,18 +67,29 @@
           <!-- 차트 -->
           <canvas id="hourly-chart" height="200"></canvas>
 
-
         </div>
       </div>
-
 
 
       <div class="col-lg-6 col-12 mb-4">
-        <div class="card-box h-100 d-flex flex-column justify-content-between" style="height: 400px;">
+        <div class="card-box h-100 d-flex flex-column justify-content-between" style="min-height: 360px;">
           <div class="section-title text-start">사용자 재방문률</div>
 
+          <div class="flex-grow-1 d-flex flex-column align-items-center justify-content-center">
+            <div style="width: 100%; max-width: 500px; aspect-ratio: 1 / 1; position: relative;">
+              <canvas id="user-usage-summary"></canvas>
+
+              <div id="user-usage-center-label"
+                   style="position: absolute; top: 46%; left: 50%; transform: translate(-50%, -50%);
+                    text-align: center; font-weight: bold; font-size: 25px;"></div>
+            </div>
+            <br>
+
+            <div class="text-muted mt-2" id="user-usage-total-text" style="font-size: 18px;"></div>
+          </div>
         </div>
       </div>
+
     </div>
 
 


### PR DESCRIPTION
### 1. 충전소별 사용자 이용횟수 통계 API 구현
> 충전소별로 이용자들을 종합하고, 각 이용자의 충전 횟수를 세어 1회 사용, 2회 사용 3~4회 사용, 5회 이상 사용 등 
총 4 그룹으로 나누어 통계를 내는 API 입니다.

[요청]
GET: `/api/stations/{stationId}/user-usage-summary`

[응답]
```json
{
    "once": 0,
    "twice": 1,
    "thirdAndFourth": 0,
    "fifthOrMore": 1
}
```

once - 1회 사용자 숫자
twice - 2회 사용자 숫자 (재방문 고객)
thirdAndFourth - 3~4회 사용자 숫자 (가끔 사용하는 고객)
fifthOrMore - 5회 이상 사용자 숫자 (충성고객)

<br>

### 2. 재방문율 데이터 시각화 차트 UI 구현 
> 도넛 차트로 각 횟수별 사용자를 시각적으로 확인할 수 있습니다.

부가적으로 총 이용자 숫자와(도넛 차트 가운데) 재방문율을(차트 하단) 확인할 수 있습니다.


[UI]
<img width="1904" alt="image" src="https://github.com/user-attachments/assets/36ec7030-0778-4528-89b9-daa390f17655" />

