### PR TITLE
Feat: 예약 미이행(노쇼)율 조회 기능 구현 (예약 탭)

### DIFF
--- a/src/main/java/com/chargeset/chargeset_server/controller/ReservationApiController.java
+++ b/src/main/java/com/chargeset/chargeset_server/controller/ReservationApiController.java
@@ -1,6 +1,7 @@
 package com.chargeset.chargeset_server.controller;
 
 import com.chargeset.chargeset_server.document.status.ReservationStatus;
+import com.chargeset.chargeset_server.dto.reservation.NoShowCountResponse;
 import com.chargeset.chargeset_server.dto.reservation.ReservationInfoResponse;
 import com.chargeset.chargeset_server.service.ReservationService;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -49,6 +51,14 @@ public class ReservationApiController {
         if (to == null) to = LocalDate.now();
         if (from == null) from = LocalDate.now().minusMonths(3);
         return reservationService.getReservationStats(from, to, stationId, status, pageable);
+    }
+
+    /**
+     * 3. 노쇼율 집계 - 예약
+     */
+    @GetMapping("/no-show")
+    public ResponseEntity<NoShowCountResponse> noShow() {
+        return ResponseEntity.ok(reservationService.getNoShowCount());
     }
 
 }

--- a/src/main/java/com/chargeset/chargeset_server/dto/charging_station/ChargingStationInfo.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/charging_station/ChargingStationInfo.java
@@ -1,13 +1,11 @@
 package com.chargeset.chargeset_server.dto.charging_station;
 
 import com.chargeset.chargeset_server.document.Location;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-@Data
+@Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChargingStationInfo {      // 위치 정보만 담는다
 
     private String id;

--- a/src/main/java/com/chargeset/chargeset_server/dto/charging_station/EvseStatusCount.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/charging_station/EvseStatusCount.java
@@ -1,12 +1,10 @@
 package com.chargeset.chargeset_server.dto.charging_station;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-@Data
+@Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EvseStatusCount {
     private String status;
     private int count;

--- a/src/main/java/com/chargeset/chargeset_server/dto/charging_station/EvseStatusSummary.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/charging_station/EvseStatusSummary.java
@@ -1,12 +1,13 @@
 package com.chargeset.chargeset_server.dto.charging_station;
 
 import com.chargeset.chargeset_server.document.status.EvseStatus;
-import lombok.Data;
+import lombok.*;
 
 import java.util.EnumMap;
 import java.util.List;
 
-@Data
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EvseStatusSummary {
 
     private int available;

--- a/src/main/java/com/chargeset/chargeset_server/dto/reservation/NoShowCountResponse.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/reservation/NoShowCountResponse.java
@@ -2,24 +2,21 @@ package com.chargeset.chargeset_server.dto.reservation;
 
 import lombok.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NoShowCountResponse {
     private int totalStationCount;
     private double totalNoShowRate;
     private long totalNoShowCount;
     private long totalCompleteCount;
-    private long totalReservationCount;
+    private long totalFinishedReservationCount;
     private List<ReservationNoShowCount> data;
+    private LocalDate fromDate;
+    private LocalDate toDate;
+    private double previousNoShowRate;
 
-    public NoShowCountResponse(int totalStationCount, long totalNoShowCount, long totalCompleteCount, List<ReservationNoShowCount> data) {
-        this.totalStationCount = totalStationCount;
-        this.totalNoShowCount = totalNoShowCount;
-        this.totalCompleteCount = totalCompleteCount;
-        this.totalReservationCount = totalCompleteCount + totalNoShowCount;
-        this.totalNoShowRate = (double) totalNoShowCount / this.totalReservationCount;
-        this.data = data;
-    }
 }

--- a/src/main/java/com/chargeset/chargeset_server/dto/reservation/NoShowCountResponse.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/reservation/NoShowCountResponse.java
@@ -1,0 +1,25 @@
+package com.chargeset.chargeset_server.dto.reservation;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoShowCountResponse {
+    private int totalStationCount;
+    private double totalNoShowRate;
+    private long totalNoShowCount;
+    private long totalCompleteCount;
+    private long totalReservationCount;
+    private List<ReservationNoShowCount> data;
+
+    public NoShowCountResponse(int totalStationCount, long totalNoShowCount, long totalCompleteCount, List<ReservationNoShowCount> data) {
+        this.totalStationCount = totalStationCount;
+        this.totalNoShowCount = totalNoShowCount;
+        this.totalCompleteCount = totalCompleteCount;
+        this.totalReservationCount = totalCompleteCount + totalNoShowCount;
+        this.totalNoShowRate = (double) totalNoShowCount / this.totalReservationCount;
+        this.data = data;
+    }
+}

--- a/src/main/java/com/chargeset/chargeset_server/dto/reservation/ReservationInfoResponse.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/reservation/ReservationInfoResponse.java
@@ -1,8 +1,14 @@
 package com.chargeset.chargeset_server.dto.reservation;
 
-import lombok.Data;
+import lombok.AccessLevel;
 
-@Data
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReservationInfoResponse {
     private String startTime;
     private String endTime;

--- a/src/main/java/com/chargeset/chargeset_server/dto/reservation/ReservationNoShowCount.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/reservation/ReservationNoShowCount.java
@@ -1,0 +1,12 @@
+package com.chargeset.chargeset_server.dto.reservation;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReservationNoShowCount {
+    private String stationId;
+    private long completeCount;
+    private long expiredCount;
+}

--- a/src/main/java/com/chargeset/chargeset_server/dto/tansaction/ChargingDailyStat.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/tansaction/ChargingDailyStat.java
@@ -1,14 +1,12 @@
 package com.chargeset.chargeset_server.dto.tansaction;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 
-@Data
+@Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChargingDailyStat {
     private LocalDate date;
     private long totalRevenue;  // 오늘 매출 원

--- a/src/main/java/com/chargeset/chargeset_server/dto/tansaction/ChargingHourlyStat.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/tansaction/ChargingHourlyStat.java
@@ -1,10 +1,10 @@
 package com.chargeset.chargeset_server.dto.tansaction;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.*;
 
-@Data
+@Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChargingHourlyStat {
     private String hour;        // "00:00" ~ "23:00"
     private long count;          // 건수

--- a/src/main/java/com/chargeset/chargeset_server/dto/tansaction/ChargingProfileResponse.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/tansaction/ChargingProfileResponse.java
@@ -3,15 +3,12 @@ package com.chargeset.chargeset_server.dto.tansaction;
 import com.chargeset.chargeset_server.document.ChargingSchedulePeriod;
 import com.chargeset.chargeset_server.document.Transaction;
 import com.chargeset.chargeset_server.utils.TimeUtils;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChargingProfileResponse {
 
     private String transactionId;

--- a/src/main/java/com/chargeset/chargeset_server/dto/tansaction/ChargingStatResponse.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/tansaction/ChargingStatResponse.java
@@ -1,12 +1,12 @@
 package com.chargeset.chargeset_server.dto.tansaction;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.*;
 
 import java.util.List;
 
-@Data
+@Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChargingStatResponse {
     private long totalCount;
     private long totalRevenue;

--- a/src/main/java/com/chargeset/chargeset_server/dto/tansaction/ChargingUsageResponse.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/tansaction/ChargingUsageResponse.java
@@ -1,10 +1,10 @@
 package com.chargeset.chargeset_server.dto.tansaction;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.*;
 
-@Data
+@Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChargingUsageResponse {
 
     private long once;

--- a/src/main/java/com/chargeset/chargeset_server/dto/tansaction/HourlyStatResponse.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/tansaction/HourlyStatResponse.java
@@ -1,13 +1,13 @@
 package com.chargeset.chargeset_server.dto.tansaction;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.util.List;
 
-@Data
+@Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class HourlyStatResponse {
     private LocalDate date;
     private String stationId;

--- a/src/main/java/com/chargeset/chargeset_server/dto/tansaction/TransactionInfoResponse.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/tansaction/TransactionInfoResponse.java
@@ -1,9 +1,11 @@
 package com.chargeset.chargeset_server.dto.tansaction;
 
 import com.chargeset.chargeset_server.document.status.TransactionStatus;
-import lombok.Data;
+import lombok.*;
 
-@Data
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TransactionInfoResponse {
 
     private String startTime;

--- a/src/main/java/com/chargeset/chargeset_server/dto/tansaction/UsageBucketResult.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/tansaction/UsageBucketResult.java
@@ -1,10 +1,10 @@
 package com.chargeset.chargeset_server.dto.tansaction;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.*;
 
-@Data
+@Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UsageBucketResult {
     private String id;
     private long userCount;

--- a/src/main/java/com/chargeset/chargeset_server/dto/tansaction/WeeklyStatResponse.java
+++ b/src/main/java/com/chargeset/chargeset_server/dto/tansaction/WeeklyStatResponse.java
@@ -1,12 +1,12 @@
 package com.chargeset.chargeset_server.dto.tansaction;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.*;
 
 import java.util.List;
 
-@Data
+@Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WeeklyStatResponse {
     private long weeklyTotalCount;
     private long weeklyTotalRevenue;

--- a/src/main/java/com/chargeset/chargeset_server/repository/reservation/ReservationCustomRepository.java
+++ b/src/main/java/com/chargeset/chargeset_server/repository/reservation/ReservationCustomRepository.java
@@ -2,13 +2,18 @@ package com.chargeset.chargeset_server.repository.reservation;
 
 import com.chargeset.chargeset_server.document.status.ReservationStatus;
 import com.chargeset.chargeset_server.dto.reservation.ReservationInfoResponse;
+import com.chargeset.chargeset_server.dto.reservation.ReservationNoShowCount;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public interface ReservationCustomRepository {
     Page<ReservationInfoResponse> findTodayReservations(Pageable pageable);
+
     Page<ReservationInfoResponse> findReservationsWithFilter(LocalDate from, LocalDate to, String stationId,
                                                              ReservationStatus status, Pageable pageable);
+
+    List<ReservationNoShowCount> getNoShowCounts();
 }

--- a/src/main/java/com/chargeset/chargeset_server/repository/reservation/ReservationCustomRepository.java
+++ b/src/main/java/com/chargeset/chargeset_server/repository/reservation/ReservationCustomRepository.java
@@ -15,5 +15,5 @@ public interface ReservationCustomRepository {
     Page<ReservationInfoResponse> findReservationsWithFilter(LocalDate from, LocalDate to, String stationId,
                                                              ReservationStatus status, Pageable pageable);
 
-    List<ReservationNoShowCount> getNoShowCounts();
+    List<ReservationNoShowCount> getNoShowCounts(LocalDate from, LocalDate to);
 }

--- a/src/main/java/com/chargeset/chargeset_server/repository/reservation/ReservationCustomRepositoryImpl.java
+++ b/src/main/java/com/chargeset/chargeset_server/repository/reservation/ReservationCustomRepositoryImpl.java
@@ -104,10 +104,14 @@ public class ReservationCustomRepositoryImpl implements ReservationCustomReposit
      * 3. 충전소별 노쇼 / 완료 예약 조회
      */
     @Override
-    public List<ReservationNoShowCount> getNoShowCounts() {
+    public List<ReservationNoShowCount> getNoShowCounts(LocalDate from, LocalDate to) {
+
+        Pair<Instant, Instant> utcRangeInKST = TimeUtils.getUTCRangeInKST(from, to);
 
         MatchOperation match = Aggregation.match(
                 Criteria.where("reservationStatus").in("COMPLETED", "EXPIRED")
+                        .and("startTime").gte(utcRangeInKST.getFirst())
+                        .and("endTime").lte(utcRangeInKST.getSecond())
         );
 
         // 1차 그룹핑: 충전소 + 상태별

--- a/src/main/java/com/chargeset/chargeset_server/repository/user/UserRepository.java
+++ b/src/main/java/com/chargeset/chargeset_server/repository/user/UserRepository.java
@@ -1,7 +1,0 @@
-package com.chargeset.chargeset_server.repository.user;
-
-import com.chargeset.chargeset_server.document.User;
-import org.springframework.data.mongodb.repository.MongoRepository;
-
-public interface UserRepository extends MongoRepository<User, String> {
-}

--- a/src/main/java/com/chargeset/chargeset_server/service/ReservationService.java
+++ b/src/main/java/com/chargeset/chargeset_server/service/ReservationService.java
@@ -2,7 +2,9 @@ package com.chargeset.chargeset_server.service;
 
 import com.chargeset.chargeset_server.document.Reservation;
 import com.chargeset.chargeset_server.document.status.ReservationStatus;
+import com.chargeset.chargeset_server.dto.reservation.NoShowCountResponse;
 import com.chargeset.chargeset_server.dto.reservation.ReservationInfoResponse;
+import com.chargeset.chargeset_server.dto.reservation.ReservationNoShowCount;
 import com.chargeset.chargeset_server.repository.reservation.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -37,5 +40,23 @@ public class ReservationService {
             throw new IllegalArgumentException("조회 시작일은 조회 종료일 보다 앞서야 합니다");
         }
         return reservationRepository.findReservationsWithFilter(from, to, stationId, reservationStatus, pageable);
+    }
+
+    /**
+     * 3. 충전소별 No Show / complete 예약 집계
+     */
+    public NoShowCountResponse getNoShowCount() {
+        List<ReservationNoShowCount> results = reservationRepository.getNoShowCounts();
+
+        long totalNoShowCount = 0;
+        long totalCompleteCount = 0;
+        int totalStationCount = 0;
+        for (ReservationNoShowCount result : results) {
+            totalNoShowCount += result.getExpiredCount();
+            totalCompleteCount += result.getCompleteCount();
+            totalStationCount++;
+        }
+
+        return new NoShowCountResponse(totalStationCount, totalNoShowCount, totalCompleteCount, results);
     }
 }

--- a/src/main/java/com/chargeset/chargeset_server/utils/TimeUtils.java
+++ b/src/main/java/com/chargeset/chargeset_server/utils/TimeUtils.java
@@ -16,41 +16,42 @@ public class TimeUtils {
     private static final DateTimeFormatter DEFAULT_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     public static Pair<Instant, Instant> getTodayRangeInKST() {
-        LocalDate today = LocalDate.now(KST);
-        return getInputDayRangeInKST(today);
+        return getRangeInKST(LocalDate.now(KST), LocalDate.now(KST));
     }
 
     public static Pair<Instant, Instant> getWeeklyRangeInKST() {
         LocalDate today = LocalDate.now(KST);
-        LocalDate sevenDaysAgo = today.minusDays(6);
-        Instant startOfDay = sevenDaysAgo.atStartOfDay(KST).toInstant();
-        Instant endOfDay = today.plusDays(1).atStartOfDay(KST).toInstant();
-        return Pair.of(startOfDay, endOfDay);
+        return getRangeInKST(today.minusDays(6), today);
     }
 
     public static Pair<Instant, Instant> getMonthlyRangeInKST() {
         LocalDate today = LocalDate.now(KST);
-        LocalDate sevenDaysAgo = today.minusDays(30);
-        Instant startOfDay = sevenDaysAgo.atStartOfDay(KST).toInstant();
-        Instant endOfDay = today.plusDays(1).atStartOfDay(KST).toInstant();
-        return Pair.of(startOfDay, endOfDay);
+        return getRangeInKST(today.minusDays(30), today);
+    }
+
+    public static Pair<Instant, Instant> getUTCRangeInKST(LocalDate from, LocalDate to) {
+        return getRangeInKST(from, to);
     }
 
     public static Pair<Instant, Instant> getInputDayRangeInKST(LocalDate date) {
-        Instant startOfDay = date.atStartOfDay(KST).toInstant();
-        Instant endOfDay = date.plusDays(1).atStartOfDay(KST).toInstant();
-        return Pair.of(startOfDay, endOfDay);
+        return getRangeInKST(date, date);
     }
 
     public static Instant convertDateToUTC(LocalDate date) {
-        return date.atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant();
+        return date.atStartOfDay(KST).toInstant();
     }
 
     public static LocalDateTime convertInstantToKST(Instant instant) {
-        return LocalDateTime.ofInstant(instant, ZoneId.of("Asia/Seoul"));
+        return LocalDateTime.ofInstant(instant, KST);
     }
 
     public static String formatInstantToKSTString(Instant instant) {
         return convertInstantToKST(instant).format(DEFAULT_FORMATTER);
+    }
+
+    private static Pair<Instant, Instant> getRangeInKST(LocalDate startDate, LocalDate endDate) {
+        Instant start = startDate.atStartOfDay(KST).toInstant();
+        Instant end = endDate.plusDays(1).atStartOfDay(KST).toInstant(); // inclusive
+        return Pair.of(start, end);
     }
 }

--- a/src/main/resources/static/css/common.css
+++ b/src/main/resources/static/css/common.css
@@ -45,3 +45,7 @@
     font-weight: bold;
     color: #333;
 }
+
+#summary-cards .card {
+    border-width: 2px;
+}

--- a/src/main/resources/static/css/transaction.css
+++ b/src/main/resources/static/css/transaction.css
@@ -1,5 +1,0 @@
-/* transaction.css */
-
-#summary-cards .card {
-    border-width: 2px;
-}

--- a/src/main/resources/static/js/reservation.js
+++ b/src/main/resources/static/js/reservation.js
@@ -124,7 +124,7 @@ function setSummaryComments(data) {
     const message = `
         <div class="mb-1">
            ${data.fromDate} ~ ${data.toDate}</strong> 동안 전체 충전소의 
-            <br> <strong class="text-primary">${data.totalFinishedReservationCount}</strong>건의 예약 중 
+            <br> <strong class="text-primary">${data.totalFinishedReservationCount}</strong>건의 종료된 예약 중 
             <strong class="text-danger">${data.totalNoShowCount}</strong>건이 미이행되어<br>
             <span class="text-dark">노쇼율은 <strong>${currentRate}%</strong>입니다.</span>
         </div>

--- a/src/main/resources/templates/reservation.html
+++ b/src/main/resources/templates/reservation.html
@@ -20,6 +20,52 @@
         <hr>
 
 
+        <div class="card-box">
+            <div class="section-title mb-3">충전소별 미이행(노쇼) 예약 정보</div>
+
+            <div class="row row-cols-1 row-cols-md-2 g-3 mb-4" id="summary-cards">
+                <div class="col">
+                    <div class="card border-primary shadow-sm h-100">
+                        <div class="card-body">
+                            <h5 class="card-title text-primary" id="summary-first-title">충전소 1</h5>
+                            <p class="card-text mb-1">
+                                <strong>정상 완료 건수:</strong> <span id="summary-first-complete">-</span> 건
+                            </p>
+                            <p class="card-text mb-1">
+                                <strong>미이행 건수:</strong> <span id="summary-first-no-show">-</span> 건
+                            </p>
+                            <p class="card-text mb-0">
+                                <strong>미이행 비율:</strong> <span id="summary-first-no-show-rate">-</span> %
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col">
+                    <div class="card border-success shadow-sm h-100">
+                        <div class="card-body">
+                            <h5 class="card-title text-success" id="summary-second-title">충전소 2</h5>
+                            <p class="card-text mb-1">
+                                <strong>정상 완료 건수:</strong> <span id="summary-second-complete">-</span> 건
+                            </p>
+                            <p class="card-text mb-1">
+                                <strong>미이행 건수:</strong> <span id="summary-second-no-show">-</span> 건
+                            </p>
+                            <p class="card-text mb-0">
+                                <strong>미이행 비율:</strong> <span id="summary-second-no-show-rate">-</span> %
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 결과 정리 멘트 -->
+            <div id="summary-result-message" class="mt-3 px-3 text-center fw-semibold"
+                 style="font-size: 16px; line-height: 1.8;"></div>
+
+        </div>
+
+
         <!-- 전체 예약 조회  -->
         <div class="card-box">
             <div class="section-title">예약 조회</div>
@@ -39,7 +85,7 @@
 
                 <!-- 상태 선택 -->
                 <div>
-                    <label for="status-select" class="form-label mb-1">충전 상태</label>
+                    <label for="status-select" class="form-label mb-1">예약 상태</label>
                     <select id="status-select" class="form-select" style="min-width: 160px;">
                         <option value="">전체</option>
                         <option value="COMPLETED">충전 완료된 예약</option>

--- a/src/main/resources/templates/reservation.html
+++ b/src/main/resources/templates/reservation.html
@@ -21,7 +21,7 @@
 
 
         <div class="card-box">
-            <div class="section-title mb-3">충전소별 미이행(노쇼) 예약 정보</div>
+            <div class="section-title mb-3">최근 30일 충전소별 미이행(노쇼) 예약 정보</div>
 
             <div class="row row-cols-1 row-cols-md-2 g-3 mb-4" id="summary-cards">
                 <div class="col">
@@ -140,9 +140,6 @@
                 </ul>
             </nav>
         </div>
-
-
-
 
     </div>
 </div>

--- a/src/main/resources/templates/station.html
+++ b/src/main/resources/templates/station.html
@@ -15,7 +15,7 @@
 
   <div class="container-fluid">
 
-    <h1 class="page-title" th:text="${chargingStationInfo.name}"></h1>
+    <h1 class="page-title" th:text="|${chargingStationInfo.name} (${stationId})|"></h1>
     <h4 style="color: dimgray" th:text="${chargingStationInfo.location.address}"></h4>
 
     <hr/>


### PR DESCRIPTION
### 2. 예약 미이행율 API 구현
> 최근 30일 동안 충전소별 각각의 예약 이행/미이행 건수와 미이행 비율을 집계할수 있고, 
전체 충전소의 예약 미이행률과 이전달의 미이행률 또한 조회할수 있는 API 입니다.

[요청]
GET: `/api/reservation/no-show`

[응답]
```json
{
    "totalStationCount": 2,
    "totalNoShowRate": 0.125,
    "totalNoShowCount": 1,
    "totalCompleteCount": 7,
    "totalFinishedReservationCount": 8,
    "data": [
        {
            "stationId": "ST-002",
            "completeCount": 1,
            "expiredCount": 0
        },
        {
            "stationId": "ST-001",
            "completeCount": 6,
            "expiredCount": 1
        }
    ],
    "fromDate": "2025-03-26",
    "toDate": "2025-04-24",
    "previousNoShowRate": 0.0
}
```

<br>

### 2. UI 구현
> 예약 미이행률을 충전소별로 비교하여 확인할 수 있습니다.

이전달과 이번달의 전체 충전소 예약 미이행률을 비교 분석한 결과도 확인할 수 있습니다.

<img width="1467" alt="image" src="https://github.com/user-attachments/assets/2fb37f7b-1f0e-4c65-b018-53d40c0bb97c" />
